### PR TITLE
[Do not merge] Make more consistent with the Stripe React Native

### DIFF
--- a/ios/StripeIdentityReactNative.swift
+++ b/ios/StripeIdentityReactNative.swift
@@ -6,7 +6,7 @@ class StripeIdentityReactNative: NSObject {
   var verificationSheet: IdentityVerificationSheet?
 
 
-    @objc func `init`(_ options: NSDictionary) -> Void {
+    @objc func initIdentityVerificationSheet(_ options: NSDictionary) -> Void {
     guard let verificationSessionId = options["sessionId"] as? String else {
         assertionFailure("Did not receive a valid id.")
         return
@@ -34,20 +34,38 @@ class StripeIdentityReactNative: NSObject {
     }
   }
 
-  @objc func present(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+  @objc func presentIdentityVerificationSheet(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
       DispatchQueue.main.async {
         self.verificationSheet?.presentInternal(
             from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController(),
             completion: { result in
                 switch result {
                 case .flowCompleted:
-                    resolve(["status": "Completed"])
+                    resolve(["result": "FlowCompleted"])
                 case .flowCanceled:
-                    resolve(["status": "Canceled"])
-                case .flowFailed(_):
-                    resolve(["status": "Failed"])
+                    resolve(["result": "FlowCanceled"])
+                case .flowFailed(let error):
+                    // The error currently isn't returned to the SDK. Should this throw the error
+                    resolve([
+                        "result": "FlowFailed",
+                        "error": createError("FlowFailed", error as NSError)
+                    ])
                 }
             })
       }
   }
+}
+// NOTE: Duplicated from https://github.com/stripe/stripe-react-native/blob/5e8045a12351b72714124b7e797146c326964973/ios/Errors.swift#L76
+
+func createError (_ code: String, _ error: NSError?) -> NSDictionary {
+    let value: NSDictionary = [
+        "code": code,
+        "message": error?.userInfo["com.stripe.lib:ErrorMessageKey"] ?? error?.userInfo["NSLocalizedDescription"] ?? NSNull(),
+        "localizedMessage": error?.userInfo["NSLocalizedDescription"] ?? NSNull(),
+        "declineCode": error?.userInfo["com.stripe.lib:DeclineCodeKey"] ?? NSNull(),
+        "stripeErrorCode": error?.userInfo["com.stripe.lib:StripeErrorCodeKey"] ?? NSNull(),
+        "type": error?.userInfo["com.stripe.lib:StripeErrorTypeKey"] ?? NSNull(),
+    ]
+
+    return ["error": value]
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,10 +1,10 @@
 import StripeIdentityReactNative from './StripeIdentitySdk';
-import type { Options, IdentityStatus } from './types';
+import type { IdentityVerificationSheetOptions, IdentityVerificationSheetResult } from './types';
 
-export function init(options: Options): void {
+export function initIdentityVerificationSheet(options: IdentityVerificationSheetOptions): void {
   StripeIdentityReactNative.init(options);
 }
 
-export function present(): Promise<{ status: IdentityStatus }> {
+export function presentIdentityVerificationSheet(): Promise<{ result: IdentityVerificationSheetResult }> {
   return StripeIdentityReactNative.present();
 }

--- a/src/hooks/useStripeIdentity.tsx
+++ b/src/hooks/useStripeIdentity.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { init, present as presentIdentity } from '../functions';
-import type { IdentityStatus, Options } from '../types';
+import { initIdentityVerificationSheet, presentIdentityVerificationSheet } from '../functions';
+import type { IdentityVerificationSheetResult, IdentityVerificationSheetOptions } from '../types';
 
 /**
  * useStripeIdentity hook.
@@ -12,7 +12,7 @@ import type { IdentityStatus, Options } from '../types';
  * @example
  * ```ts
  * const fechOptionsProvider = async () => {
- *    const response = await fetch('http://api_url/create-verification-session');
+ *    const response = await fetch('http://{{YOUR_SERVER_BASE_URL}}/create-verification-session');
  *    const { id, ephemeral_key_secret } = await response.json();
  *    return {
  *      sessionId: id,
@@ -20,14 +20,14 @@ import type { IdentityStatus, Options } from '../types';
  *      merchantLogo: Image.resolveAssetSource(logo),
  *    };
  *  };
- * 
- * const { status, resent, loading } = useStripeIdentity(fetchOptionsProvider)
+ *
+ * const { result, present, loading } = useStripeIdentity(fetchOptionsProvider)
  * ```
- 
+
  */
-export function useStripeIdentity(optionsProvider: () => Promise<Options>) {
+export function useStripeIdentity(optionsProvider: () => Promise<IdentityVerificationSheetOptions>) {
   const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<IdentityStatus | undefined>();
+  const [status, setStatus] = useState<IdentityVerificationSheetResult | undefined>();
 
   const present = async () => {
     try {
@@ -35,10 +35,11 @@ export function useStripeIdentity(optionsProvider: () => Promise<Options>) {
       const options = await optionsProvider();
       init(options);
       setLoading(false);
-      const result = await presentIdentity();
+      const [result, error] = await presentIdentityVerificationSheet();
       setStatus(result.status);
     } catch (e) {
-      setStatus('Failed');
+      // How does the integrator access the error? Should we also return a nullable error from this function?
+      setStatus('FlowFailed', e);
     }
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export { useStripeIdentity } from './hooks/useStripeIdentity';
 export { init, present } from './functions';
 
 // types
-export type { Options, IdentityStatus } from './types';
+export type { IdentityVerificationSheetOptions, IdentityVerificationSheetResult } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,13 @@
 import type { ImageResolvedAssetSource } from 'react-native';
 
-export type Options = {
+export type IdentityVerificationSheetOptions = {
   sessionId: string;
   ephemeralKeySecret: string;
   merchantLogo: ImageResolvedAssetSource;
 };
 
-export type IdentityStatus = 'Completed' | 'Canceled' | 'Failed';
+export type IdentityVerificationSheetResult = 'FlowCompleted' | 'FlowCanceled' | 'FlowFailed';
 
-export type Init = (options: Options) => void;
+export type Init = (options: IdentityVerificationSheetOptions) => void;
 
-export type Present = () => Promise<{ status: IdentityStatus }>;
+export type Present = () => Promise<{ result: IdentityVerificationSheetResult }>;


### PR DESCRIPTION
While reviewing the proposed [Identity React Native integration guide](https://docs.google.com/document/d/1H3q4oFH1OOT4KvkF7m_vDidGP8aTT_IYyFxhQqms_0M/edit#), @charliecruzan-stripe and I noticed some discrepancies between some of the variable naming in React Native vs. iOS/Android SDKs as well as the Identity React Native vs. Payments React Native SDKs.

This PR is not meant to be merged but to demonstrate API changes that should be made to ensure the Identity React Native SDK is consistent with Stripe's [Payments React Native SDK](https://github.com/stripe/stripe-react-native) and Stripe Identity's [iOS SDK](https://github.com/stripe/stripe-ios/blob/master/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift) and [Android SDK](https://github.com/stripe/stripe-android/blob/6acc0414d036ddba4c22ba33dde1883b638fd8d4/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt). Since I'm not familiar with React Native, I didn't try to make this this run, but it can be used as an example of the name changes that we're looking for.

Renames the following:
- Status -> IdentitityVerificationSheetResult
- Options -> IdentitityVerificationSheetOptions
- init -> initIdentityVerificationSheet
- present -> presentIdentityVerificationSheet
- Include error from `flowFailed` result for iOS
- Update status/result naming to prepend "Flow"
