### PR TITLE
Add docs redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Stripe Identity React Native SDK</title>
+    <script>
+      window.location.href =
+        window.location.href.replace('index.html', '') +
+        'api-reference/index.html';
+    </script>
+  </head>
+  <body>
+    Redirecting ...
+  </body>
+</html>


### PR DESCRIPTION
Adds a redirect from `/docs/index.html` -> `/docs/api-reference/index.html`.

This enables us to set a GitHub pages redirect to the `/docs` folder to display the API reference.

## Testing

- `open docs/index.html`
- Verified the API reference opened in the browser