### PR TITLE
update example to use @stripe/stripe-identity-react-native

### DIFF
--- a/example/src/components/Identity.tsx
+++ b/example/src/components/Identity.tsx
@@ -9,7 +9,7 @@ import {
 import {
   useStripeIdentity,
   IdentityVerificationSheetOptions,
-} from 'stripe-identity-react-native';
+} from '@stripe/stripe-identity-react-native';
 
 type Props = {
   fetchOptions: () => Promise<IdentityVerificationSheetOptions>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "stripe-identity-react-native": ["./src/index"]
+      "@stripe/stripe-identity-react-native": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
In this [PR](https://github.com/stripe/stripe-identity-react-native/pull/69/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R2) we forgot to update dependency from the example app