### PR TITLE
null check encapsulated fragment for StripeIdentityReactNativeModule

### DIFF
--- a/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
+++ b/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
@@ -28,7 +28,7 @@ class StripeIdentityReactNativeModule(reactContext: ReactApplicationContext) : R
   }
 
   @ReactMethod
-  fun initIdentityVerificationSheet(options: ReadableMap) {
+  fun initIdentityVerificationSheet(options: ReadableMap, promise: Promise) {
     initialized = true
     val activity = currentActivity as AppCompatActivity? ?: return
 
@@ -45,6 +45,7 @@ class StripeIdentityReactNativeModule(reactContext: ReactApplicationContext) : R
       .add(requireNotNull(stripeIdentityVerificationSheetFragment), "identity_sheet_launch_fragment")
       .commit()
 
+    promise.resolve(null)
   }
 
   @ReactMethod

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 32
+        compileSdkVersion = 33
         targetSdkVersion = 31
 
         if (System.properties['os.arch'] == "aarch64") {

--- a/ios/StripeIdentityReactNative.m
+++ b/ios/StripeIdentityReactNative.m
@@ -2,7 +2,11 @@
 
 @interface RCT_EXTERN_MODULE(StripeIdentityReactNative, NSObject)
 
-RCT_EXTERN_METHOD(initIdentityVerificationSheet: (NSDictionary)options)
+RCT_EXTERN_METHOD(
+                  initIdentityVerificationSheet: (NSDictionary)options
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                 )
 
 RCT_EXTERN_METHOD(
                   presentIdentityVerificationSheet:(RCTPromiseResolveBlock)resolve

--- a/ios/StripeIdentityReactNative.swift
+++ b/ios/StripeIdentityReactNative.swift
@@ -4,9 +4,10 @@ import UIKit
 @objc(StripeIdentityReactNative)
 class StripeIdentityReactNative: NSObject {
     var verificationSheet: IdentityVerificationSheet?
-    
-    
-    @objc func initIdentityVerificationSheet(_ options: NSDictionary) -> Void {
+
+
+    @objc func initIdentityVerificationSheet(_ options: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock,
+                          rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         guard let verificationSessionId = options["sessionId"] as? String else {
             assertionFailure("Did not receive a valid id.")
             return
@@ -32,8 +33,9 @@ class StripeIdentityReactNative: NSObject {
                 )
             )
         }
+        resolve(NSNull())
     }
-    
+
     @objc func presentIdentityVerificationSheet(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
             self.verificationSheet?.present(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -4,13 +4,9 @@ import type {
   IdentityVerificationSheetResult,
 } from './types';
 
-export function presentIdentityVerificationSheet(
+export async function presentIdentityVerificationSheet(
   options: IdentityVerificationSheetOptions
 ): Promise<IdentityVerificationSheetResult> {
-  const initVerificationSheet = async () => {
-    await StripeIdentityReactNative.initIdentityVerificationSheet(options);
-  };
-  initVerificationSheet();
-
-  return StripeIdentityReactNative.presentIdentityVerificationSheet();
+  await StripeIdentityReactNative.initIdentityVerificationSheet(options);
+  return await StripeIdentityReactNative.presentIdentityVerificationSheet();
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -7,6 +7,10 @@ import type {
 export function presentIdentityVerificationSheet(
   options: IdentityVerificationSheetOptions
 ): Promise<IdentityVerificationSheetResult> {
-  StripeIdentityReactNative.initIdentityVerificationSheet(options);
+  const initVerificationSheet = async () => {
+    await StripeIdentityReactNative.initIdentityVerificationSheet(options);
+  };
+  initVerificationSheet();
+
   return StripeIdentityReactNative.presentIdentityVerificationSheet();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type IdentityVerificationSheetResult = {
 
 export type InitIdentityVerificationSheet = (
   options: IdentityVerificationSheetOptions
-) => void;
+) => Promise<void>;
 
 export type PresentIdentityVerificationSheet =
   () => Promise<IdentityVerificationSheetResult>;


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Null check created fragment in `StripeIdentityReactNativeModule` and only make callback to it when there is one already created.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The `StripeIdentityReactNativeModule` will be created even though the client doesn't invoke stripe API, as a result `mActivityEventListener` might be invoked when `stripeIdentityVerificationSheetFragment` is not initialized, causing a crash.

This fix is inspired by stripe's payment react native SDK [here](https://github.com/stripe/stripe-react-native/blob/e6d39ef31804b1f96636464388e868f49a5dac69/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt#L48)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
