### PR TITLE
bump Android to 20.24.+ and iOS to 20.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Alternatively use the `plugin-transform-typescript` plugin in your project.
     > See more details about material theme [here](https://material.io/develop/android/theming/dark).
 
 #### iOS
+> Note: [Xcode 13 is no longer supported by Apple](https://developer.apple.com/news/upcoming-requirements/). Please upgrade to Xcode 14.1 or later.
+
 - Compatible with apps targeting iOS 13.0 or above.
 - Run `pod install` in your `ios` directory to ensure that you also install the required native dependencies.
 - Stripe Identity requires access to the device’s camera to capture identity documents. To enable your app to request camera permissions:

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
+# When StripeIdentityReactNative_kotlinVersion and StripeIdentityReactNative_stripeVersion is updated, also need to update StripeSdk_kotlinVersion and StripeSdk_stripeVersion in https://github.com/stripe/stripe-react-native/blob/master/android/gradle.properties
 StripeIdentityReactNative_kotlinVersion=1.8.0
 StripeIdentityReactNative_stripeVersion=20.24.+
 StripeIdentityReactNative_compileSdkVersion=31

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 StripeIdentityReactNative_kotlinVersion=1.8.0
-StripeIdentityReactNative_stripeVersion=20.23.+
+StripeIdentityReactNative_stripeVersion=20.24.+
 StripeIdentityReactNative_compileSdkVersion=31
 StripeIdentityReactNative_targetSdkVersion=31

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -360,7 +360,7 @@ PODS:
     - React-RCTImage
   - stripe-identity-react-native (0.1.6):
     - React-Core
-    - StripeIdentity (= 23.7.0)
+    - StripeIdentity (~> 23.7.0)
   - StripeCameraCore (23.7.0):
     - StripeCore (= 23.7.0)
   - StripeCore (23.7.0)
@@ -575,7 +575,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
-  stripe-identity-react-native: 653eab1578f1f9ce338172bc9d98a06ed7bbfd48
+  stripe-identity-react-native: 1bfac0618c3b38adbbc1eeb0ba224aa0f4ae051c
   StripeCameraCore: 3f758142a72651bab1f5ca2e6b950414ddef9e94
   StripeCore: bec0c90f6e153abeba70f015be25e17fada10084
   StripeIdentity: 756d350cd1f9a9d54cf992ddaf09030f3035ec6e

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -358,18 +358,18 @@ PODS:
   - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
-  - stripe-identity-react-native (0.1.5):
+  - stripe-identity-react-native (0.1.6):
     - React-Core
-    - StripeIdentity (= 23.6.0)
-  - StripeCameraCore (23.6.0):
-    - StripeCore (= 23.6.0)
-  - StripeCore (23.6.0)
-  - StripeIdentity (23.6.0):
-    - StripeCameraCore (= 23.6.0)
-    - StripeCore (= 23.6.0)
-    - StripeUICore (= 23.6.0)
-  - StripeUICore (23.6.0):
-    - StripeCore (= 23.6.0)
+    - StripeIdentity (= 23.7.0)
+  - StripeCameraCore (23.7.0):
+    - StripeCore (= 23.7.0)
+  - StripeCore (23.7.0)
+  - StripeIdentity (23.7.0):
+    - StripeCameraCore (= 23.7.0)
+    - StripeCore (= 23.7.0)
+    - StripeUICore (= 23.7.0)
+  - StripeUICore (23.7.0):
+    - StripeCore (= 23.7.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -575,11 +575,11 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
-  stripe-identity-react-native: a14642da3fbd9dd1df5d095c2db17b664dd797ba
-  StripeCameraCore: 253d822d1eef98548b8eb5cdcd1a41f098403c17
-  StripeCore: 0e83ad26d508e5a8e9eb04d6ddd3cbb08a3f7816
-  StripeIdentity: 7ee8daf9704a6e8eb01cf16252685c0408f2dbcf
-  StripeUICore: 81bac0f54df659ab7c5dd4f5a57719a5fecdcdc9
+  stripe-identity-react-native: 653eab1578f1f9ce338172bc9d98a06ed7bbfd48
+  StripeCameraCore: 3f758142a72651bab1f5ca2e6b950414ddef9e94
+  StripeCore: bec0c90f6e153abeba70f015be25e17fada10084
+  StripeIdentity: 756d350cd1f9a9d54cf992ddaf09030f3035ec6e
+  StripeUICore: f940d7e6908ba241380f25bf7062919890dd81e2
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/stripe-identity-react-native.podspec
+++ b/stripe-identity-react-native.podspec
@@ -1,7 +1,9 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '23.7.0'
+
+# When stripe_version is updated, also need to update stripe_version in https://github.com/stripe/stripe-react-native/blob/master/stripe-react-native.podspec
+stripe_version = '~> 23.7.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-identity-react-native'

--- a/stripe-identity-react-native.podspec
+++ b/stripe-identity-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '23.6.0'
+stripe_version = '23.7.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-identity-react-native'


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
[Android](https://github.com/stripe/stripe-android/releases/tag/v20.24.1): Pick up the latest minor update fixing the [dagger duplicate name](https://github.com/stripe/stripe-android/pull/6602) issue

[iOS](https://github.com/stripe/stripe-ios/releases/tag/23.7.0): Support test mode

Related change: https://github.com/stripe/stripe-react-native/pull/1375

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
