### PR TITLE
bump up native Android and iOS versions

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 # When StripeIdentityReactNative_kotlinVersion and StripeIdentityReactNative_stripeVersion is updated, also need to update StripeSdk_kotlinVersion and StripeSdk_stripeVersion in https://github.com/stripe/stripe-react-native/blob/master/android/gradle.properties
 StripeIdentityReactNative_kotlinVersion=1.8.0
-StripeIdentityReactNative_stripeVersion=20.25.+
+StripeIdentityReactNative_stripeVersion=20.28.+
 StripeIdentityReactNative_compileSdkVersion=31
 StripeIdentityReactNative_targetSdkVersion=31

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -358,18 +358,18 @@ PODS:
   - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
-  - stripe-identity-react-native (0.1.7):
+  - stripe-identity-react-native (0.1.8):
     - React-Core
-    - StripeIdentity (~> 23.8.0)
-  - StripeCameraCore (23.8.0):
-    - StripeCore (= 23.8.0)
-  - StripeCore (23.8.0)
-  - StripeIdentity (23.8.0):
-    - StripeCameraCore (= 23.8.0)
-    - StripeCore (= 23.8.0)
-    - StripeUICore (= 23.8.0)
-  - StripeUICore (23.8.0):
-    - StripeCore (= 23.8.0)
+    - StripeIdentity (~> 23.12.0)
+  - StripeCameraCore (23.12.0):
+    - StripeCore (= 23.12.0)
+  - StripeCore (23.12.0)
+  - StripeIdentity (23.12.0):
+    - StripeCameraCore (= 23.12.0)
+    - StripeCore (= 23.12.0)
+    - StripeUICore (= 23.12.0)
+  - StripeUICore (23.12.0):
+    - StripeCore (= 23.12.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -575,11 +575,11 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
-  stripe-identity-react-native: f9773e4833229d87b4bacae79f4bde401d50a44b
-  StripeCameraCore: a76841869964848d06c8b8c333017b3589f72407
-  StripeCore: 91164d69b8593f44df9ee93e56a00355592068b6
-  StripeIdentity: 4be6a9ddb09997e63e79e74b7b7007192002756a
-  StripeUICore: 1dc4d2f9afcd908db85190e9091dfe260a1861fe
+  stripe-identity-react-native: 3add886513dc972d1181f2bd7b2c376d45ad2adb
+  StripeCameraCore: 792de1f4261ad5ee2f58d91171f3373ad9e994d6
+  StripeCore: 7b08fd286e8f8f5336eb725bc7ed1d2a4705cdc4
+  StripeIdentity: fc79b2848e71d1132003cde729e0007c32a694a5
+  StripeUICore: 4a76fa59cab679e1b2fe1ad37d6b08c5bf2ada54
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,8 @@
     "@react-navigation/native-stack": "^6.5.2",
     "react": "18.0.0",
     "react-native": "0.69.1",
-    "react-native-radio-buttons-group": "^2.3.2",
+    "react-native-dropdown-select-list": "^2.0.4",
+    "react-native-radio-buttons-group": "^3.0.2",
     "react-native-safe-area-context": "^4.2.4",
     "react-native-screens": "^3.15.0"
   },

--- a/example/src/components/Options.tsx
+++ b/example/src/components/Options.tsx
@@ -2,12 +2,13 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import {
   AllowedTypes,
+  PhoneOtpCheckTypes,
   VerificationSessionOptions,
   VerificationType,
 } from '../types';
 import { Option } from './Option';
+import { SelectList } from 'react-native-dropdown-select-list';
 import RadioGroup from 'react-native-radio-buttons-group';
-import type { RadioButtonProps } from 'react-native-radio-buttons-group';
 
 type OptionsProps = {
   options: VerificationSessionOptions;
@@ -15,95 +16,105 @@ type OptionsProps = {
 };
 
 export function Options({ options, setOptions }: OptionsProps) {
-  const [verificationTypeRadioButtons] = useState([
+  const verificationTypeData = [
+    { key: VerificationType.DOCUMENT, value: 'Document' },
+    { key: VerificationType.ID_NUMBER, value: 'ID Number' },
+    { key: VerificationType.ADDRESS, value: 'Address' },
+    { key: VerificationType.PHONE, value: 'Phone' },
+  ];
+
+  const [phoneOtpCheckOptions] = useState([
     {
-      id: VerificationType.DOCUMENT, // acts as primary key, should be unique and non-empty string
-      label: 'Document',
-      value: VerificationType.DOCUMENT,
+      id: PhoneOtpCheckTypes.ATTEMPT, // acts as primary key, should be unique and non-empty string
+      label: PhoneOtpCheckTypes.ATTEMPT.valueOf(),
+      value: PhoneOtpCheckTypes.ATTEMPT,
       labelStyle: styles.verification_type_label,
-      selected: true,
     },
     {
-      id: VerificationType.ID_NUMBER,
-      label: 'ID Number',
-      value: VerificationType.ID_NUMBER,
+      id: PhoneOtpCheckTypes.NONE,
+      label: PhoneOtpCheckTypes.NONE.valueOf(),
+      value: PhoneOtpCheckTypes.NONE,
       labelStyle: styles.verification_type_label,
     },
     {
-      id: VerificationType.ADDRESS,
-      label: 'Address',
-      value: VerificationType.ADDRESS,
+      id: PhoneOtpCheckTypes.REQUIRED,
+      label: PhoneOtpCheckTypes.REQUIRED.valueOf(),
+      value: PhoneOtpCheckTypes.REQUIRED,
       labelStyle: styles.verification_type_label,
     },
   ]);
 
-  function onPressRadioButton(radioButtonsArray: RadioButtonProps[]) {
-    let selectedVerificaitonType = radioButtonsArray.find((prop) => {
-      return prop.selected;
+  function onPressPhoneOtpCheckOption(selectedId: string) {
+    let selectedPhoneOtpCheckType = phoneOtpCheckOptions.find((item) => {
+      return item.id === selectedId;
     })?.value;
 
     setOptions({
       ...options,
-      verificationType:
-        selectedVerificaitonType === undefined
-          ? VerificationType.DOCUMENT
-          : (selectedVerificaitonType as VerificationType),
+      phoneOtpCheckType: selectedPhoneOtpCheckType
+        ? selectedPhoneOtpCheckType
+        : PhoneOtpCheckTypes.ATTEMPT,
     });
   }
 
-  if (options.verificationType === VerificationType.DOCUMENT) {
+  const findItemByKey = (keyToFind: VerificationType) => {
+    const foundItem = verificationTypeData.find(
+      (item) => item.key === keyToFind
+    );
+    return foundItem;
+  };
+
+  function onSelectVerificationType(value: VerificationType) {
+    setOptions({
+      ...options,
+      verificationType: value,
+    });
+  }
+
+  const DocumentOptionSection = () => {
     return (
-      <View style={styles.container}>
-        <View>
-          <Text style={styles.label}>Verification Type:</Text>
-          <RadioGroup
-            radioButtons={verificationTypeRadioButtons}
-            onPress={onPressRadioButton}
-            layout="row"
-            containerStyle={styles.verification_type_container}
+      <View>
+        <Text style={styles.label}>Allowed Types:</Text>
+        <View style={styles.section}>
+          <Option
+            title="Driving License"
+            value={options.allowedTypes[AllowedTypes.DRIVING_LICENSE]}
+            onChange={(value) =>
+              setOptions({
+                ...options,
+                allowedTypes: {
+                  ...options.allowedTypes,
+                  [AllowedTypes.DRIVING_LICENSE]: value,
+                },
+              })
+            }
           />
-          <Text style={styles.label}>Allowed Types:</Text>
-          <View style={styles.section}>
-            <Option
-              title="Driving License"
-              value={options.allowedTypes[AllowedTypes.DRIVING_LICENSE]}
-              onChange={(value) =>
-                setOptions({
-                  ...options,
-                  allowedTypes: {
-                    ...options.allowedTypes,
-                    [AllowedTypes.DRIVING_LICENSE]: value,
-                  },
-                })
-              }
-            />
-            <Option
-              title="Passport"
-              value={options.allowedTypes[AllowedTypes.PASSPORT]}
-              onChange={(value) =>
-                setOptions({
-                  ...options,
-                  allowedTypes: {
-                    ...options.allowedTypes,
-                    [AllowedTypes.PASSPORT]: value,
-                  },
-                })
-              }
-            />
-            <Option
-              title="ID Card"
-              value={options.allowedTypes[AllowedTypes.ID_CARD]}
-              onChange={(value) =>
-                setOptions({
-                  ...options,
-                  allowedTypes: {
-                    ...options.allowedTypes,
-                    [AllowedTypes.ID_CARD]: value,
-                  },
-                })
-              }
-            />
-          </View>
+          <Option
+            title="Passport"
+            value={options.allowedTypes[AllowedTypes.PASSPORT]}
+            onChange={(value) =>
+              setOptions({
+                ...options,
+                allowedTypes: {
+                  ...options.allowedTypes,
+                  [AllowedTypes.PASSPORT]: value,
+                },
+              })
+            }
+          />
+          <Option
+            title="ID Card"
+            value={options.allowedTypes[AllowedTypes.ID_CARD]}
+            onChange={(value) =>
+              setOptions({
+                ...options,
+                allowedTypes: {
+                  ...options.allowedTypes,
+                  [AllowedTypes.ID_CARD]: value,
+                },
+              })
+            }
+          />
         </View>
         <Option
           title="Require ID Number"
@@ -135,15 +146,71 @@ export function Options({ options, setOptions }: OptionsProps) {
         />
       </View>
     );
+  };
+
+  if (options.verificationType === VerificationType.DOCUMENT) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.label}>Verification Type:</Text>
+        <SelectList
+          setSelected={onSelectVerificationType}
+          data={verificationTypeData}
+          save="key"
+          defaultOption={findItemByKey(options.verificationType)}
+          search={false}
+          boxStyles={styles.verification_type_container}
+        />
+        <DocumentOptionSection />
+      </View>
+    );
+  } else if (options.verificationType === VerificationType.PHONE) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.label}>Verification Type:</Text>
+        <SelectList
+          setSelected={onSelectVerificationType}
+          data={verificationTypeData}
+          save="key"
+          defaultOption={findItemByKey(options.verificationType)}
+          search={false}
+          boxStyles={styles.verification_type_container}
+        />
+        <Option
+          title="Fallback to document"
+          value={options.phoneFallbackToDocument}
+          onChange={(value) =>
+            setOptions({
+              ...options,
+              phoneFallbackToDocument: value,
+            })
+          }
+        />
+        {options.phoneFallbackToDocument ? (
+          <View>
+            <Text style={styles.label}>OTP Check:</Text>
+            <RadioGroup
+              radioButtons={phoneOtpCheckOptions}
+              selectedId={options.phoneOtpCheckType}
+              onPress={onPressPhoneOtpCheckOption}
+              layout="row"
+              containerStyle={styles.verification_type_container}
+            />
+            <DocumentOptionSection />
+          </View>
+        ) : null}
+      </View>
+    );
   } else {
     return (
       <View style={styles.container}>
         <Text style={styles.label}>Verification Type:</Text>
-        <RadioGroup
-          radioButtons={verificationTypeRadioButtons}
-          onPress={onPressRadioButton}
-          layout="row"
-          containerStyle={styles.verification_type_container}
+        <SelectList
+          setSelected={onSelectVerificationType}
+          data={verificationTypeData}
+          save="key"
+          defaultOption={findItemByKey(options.verificationType)}
+          search={false}
+          boxStyles={styles.verification_type_container}
         />
       </View>
     );

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -1,11 +1,18 @@
 import React, { useState, useCallback } from 'react';
-import { StyleSheet, Image, View, SafeAreaView } from 'react-native';
+import {
+  StyleSheet,
+  Image,
+  View,
+  SafeAreaView,
+  ScrollView,
+} from 'react-native';
 import logo from '../assets/RocketRides.png';
 import { getTestCredentials } from '../utils/api';
 import { Options } from '../components/Options';
 import { Identity } from '../components/Identity';
 import {
   AllowedTypes,
+  PhoneOtpCheckTypes,
   VerificationSessionOptions,
   VerificationType,
 } from '../types';
@@ -22,6 +29,8 @@ export function HomeScreen() {
     },
     requireLiveCapture: false,
     requireAddress: false,
+    phoneFallbackToDocument: false,
+    phoneOtpCheckType: PhoneOtpCheckTypes.ATTEMPT,
   });
 
   const fetchOptions = useCallback(async () => {
@@ -35,9 +44,11 @@ export function HomeScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Options options={options} setOptions={setOptions} />
-      <View style={styles.divider} />
-      <Identity fetchOptions={fetchOptions} />
+      <ScrollView style={styles.scrollView}>
+        <Options options={options} setOptions={setOptions} />
+        <View style={styles.divider} />
+        <Identity fetchOptions={fetchOptions} />
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -45,8 +56,9 @@ export function HomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  },
+  scrollView: {
+    marginHorizontal: 0,
   },
   divider: {
     borderBottomColor: 'black',

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -11,6 +11,12 @@ export enum AllowedTypes {
   ID_CARD = 'id_card',
 }
 
+export enum PhoneOtpCheckTypes {
+  ATTEMPT = 'attempt',
+  NONE = 'none',
+  REQUIRED = 'required',
+}
+
 export type VerificationSessionOptions = {
   verificationType: VerificationType;
   requireMatchingSelfie: boolean;
@@ -18,4 +24,6 @@ export type VerificationSessionOptions = {
   allowedTypes: Record<AllowedTypes, boolean>;
   requireLiveCapture: boolean;
   requireAddress: boolean;
+  phoneFallbackToDocument: boolean;
+  phoneOtpCheckType: PhoneOtpCheckTypes;
 };

--- a/example/src/utils/api.ts
+++ b/example/src/utils/api.ts
@@ -34,6 +34,34 @@ export const getTestCredentials = async (
           },
         }),
       });
+    } else if (options.verificationType === VerificationType.PHONE) {
+      let body = options.phoneFallbackToDocument
+        ? JSON.stringify({
+            type: options.verificationType,
+            options: {
+              phone_records: { fallback: 'document' },
+              phone_otp: { check: options.phoneOtpCheckType },
+              document: {
+                require_matching_selfie: options.requireMatchingSelfie,
+                require_id_number: options.requireIdNumber,
+                require_live_capture: options.requireLiveCapture,
+                require_address: options.requireAddress,
+                allowed_types: (
+                  Object.keys(options.allowedTypes) as AllowedTypes[]
+                ).filter((key: AllowedTypes) => options.allowedTypes[key]),
+              },
+            },
+          })
+        : JSON.stringify({
+            type: options.verificationType,
+          });
+      data = await fetch(baseURL + verifyEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: body,
+      });
     } else {
       data = await fetch(baseURL + verifyEndpoint, {
         method: 'POST',

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3887,11 +3887,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash.isequal@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
-
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
@@ -4873,17 +4868,20 @@ react-native-codegen@^0.69.1:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
+react-native-dropdown-select-list@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-dropdown-select-list/-/react-native-dropdown-select-list-2.0.4.tgz#bd63d684dd9b840d50e022985f9d0fa69eee1c2a"
+  integrity sha512-H7aRhhSHYvl5v+Ufy5CtXhaRHgrRQakWn+IexSFCP/+nUFu5yvwfmtbVEfIszMjr6szPuiabG15trrbswHlmCw==
+
 react-native-gradle-plugin@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
-react-native-radio-buttons-group@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/react-native-radio-buttons-group/-/react-native-radio-buttons-group-2.3.2.tgz#3dd50e9137b722d98543ae038671308af1421a9c"
-  integrity sha512-ebYKTddyon/+8OxZIfuowB2/0gDcRnc+H0Jn5JBjIBqh5Zo2atIbXt1RrblA5V7dAvwlLCP4B/uzR2kFcLi8VA==
-  dependencies:
-    lodash.isequal "4.5.0"
+react-native-radio-buttons-group@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-radio-buttons-group/-/react-native-radio-buttons-group-3.0.2.tgz#9016a739819030cbf58a563b2487fac46a711f02"
+  integrity sha512-5Nszk4WJGO4MeL+/4TSQRGoQErZlAaj5zAb4tis5f2J+O1tGzCMRtIARqr0WlIKwsjzH6zmcgyr9Q2Vv5xMiPw==
 
 react-native-safe-area-context@^4.2.4:
   version "4.5.0"

--- a/stripe-identity-react-native.podspec
+++ b/stripe-identity-react-native.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 # When stripe_version is updated, also need to update stripe_version in https://github.com/stripe/stripe-react-native/blob/master/stripe-react-native.podspec
-stripe_version = '~> 23.8.0'
+stripe_version = '~> 23.12.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-identity-react-native'


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Support the version for phoneV, also updated the example app to request a session with type phoneV
iOS to 23.12.0
Android to 20.28.0


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Use latest native SDK versions

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Android  | iOS |
| ------------- | ------------- |
| ![rnAndroid](https://github.com/stripe/stripe-identity-react-native/assets/79880926/f94eea2a-5909-4f57-af2a-3eb28024a5e1)  | ![rnIOS](https://github.com/stripe/stripe-identity-react-native/assets/79880926/4f82ebec-7840-443f-b4be-29a847fe738a) |




