### PR TITLE
fix crash when fragment manager doesn't support remove()

### DIFF
--- a/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
+++ b/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
@@ -34,7 +34,9 @@ class StripeIdentityReactNativeModule(reactContext: ReactApplicationContext) : R
 
     // If a fragment was already initialized, we want to remove it first
     stripeIdentityVerificationSheetFragment?.let {
-      activity.supportFragmentManager.beginTransaction().remove(it).commitAllowingStateLoss()
+      runCatching {
+        activity.supportFragmentManager.beginTransaction().remove(it).commitAllowingStateLoss()
+      }
     }
     stripeIdentityVerificationSheetFragment = StripeIdentityVerificationSheetFragment().also {
       val bundle = toBundleObject(options)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
catch the exception instead of failing
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
