### PR TITLE
Bump Android native version to 20.47.3

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 # When StripeIdentityReactNative_kotlinVersion and StripeIdentityReactNative_stripeVersion is updated, also need to update StripeSdk_kotlinVersion and StripeSdk_stripeVersion in https://github.com/stripe/stripe-react-native/blob/master/android/gradle.properties
 StripeIdentityReactNative_kotlinVersion=1.8.0
-StripeIdentityReactNative_stripeVersion=20.44.+
+StripeIdentityReactNative_stripeVersion=20.47.3
 StripeIdentityReactNative_compileSdkVersion=34
 StripeIdentityReactNative_targetSdkVersion=34


### PR DESCRIPTION
# Summary
Update Android version to 20.47.3

# Motivation
Pick up change to remove use of `usesCleartextTraffic`

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
No visual changes made.
