### PR TITLE
fix: bump StripeIdentityReactNative_stripeVersion to 21.26.+

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 # When StripeIdentityReactNative_kotlinVersion and StripeIdentityReactNative_stripeVersion is updated, also need to update StripeSdk_kotlinVersion and StripeSdk_stripeVersion in https://github.com/stripe/stripe-react-native/blob/master/android/gradle.properties
 StripeIdentityReactNative_kotlinVersion=1.8.0
-StripeIdentityReactNative_stripeVersion=20.52.+
+StripeIdentityReactNative_stripeVersion=21.26.+
 StripeIdentityReactNative_compileSdkVersion=34
 StripeIdentityReactNative_targetSdkVersion=34


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- fixes #203 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width=300 src=https://github.com/user-attachments/assets/6467189f-b796-4c80-8c1d-3839931b7aaa />  | <img width=300 src=https://github.com/user-attachments/assets/e79ea122-69c6-49e0-93e1-2b312e017eed /> |
