### PR TITLE
Fix android compilation error on RN 0.81+

### DIFF
--- a/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
+++ b/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt
@@ -30,7 +30,7 @@ class StripeIdentityReactNativeModule(reactContext: ReactApplicationContext) : R
   @ReactMethod
   fun initIdentityVerificationSheet(options: ReadableMap, promise: Promise) {
     initialized = true
-    val activity = currentActivity as AppCompatActivity? ?: return
+    val activity = reactApplicationContext.currentActivity as AppCompatActivity? ?: return
 
     // If a fragment was already initialized, we want to remove it first
     stripeIdentityVerificationSheetFragment?.let {


### PR DESCRIPTION
# Summary
Builds on Android fail for RN 0.81+ (Expo 54) with the following error:

```
[RUN_GRADLEW] e: file:///private/var/folders/.../build/node_modules/@stripe/stripe-identity-react-native/android/src/main/java/com/stripeidentityreactnative/StripeIdentityReactNativeModule.kt:33:20 Unresolved reference 'currentActivity'.
```

# Motivation
This PR fixes this issue by using the right getter to fetch the currentActivity, similar to https://github.com/react-native-datetimepicker/datetimepicker/pull/1003/files

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
- [x] Build works again :D

To test:
I have not tested backwards compatibility with Expo 53 and below