### PR TITLE
Remove jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     mavenLocal()
     google()
     mavenCentral()
-    jcenter()
   }
 
   dependencies {


### PR DESCRIPTION
Just removes jcenter() from our build.gradle.


Tested this by running the example on emulator and device.

Resolves: https://github.com/stripe/stripe-identity-react-native/issues/215