### PR TITLE
Updating a few versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # [Unreleased]
 
+### Fixed
+
+- Aligned the example app's React and React Test Renderer versions with React Native 0.84.1
+
 ### Changed
 
-- Updated `stripe-ios` to 26.4.1
-- Updated `stripe-android` to 23.13.1
-- Raised the minimum iOS deployment target to 15.0 to match `StripeIdentity` 26.4.1
+- Updated `stripe-ios` to 26.5.0
+- Updated `stripe-android` to 23.14.0
+- Raised the minimum iOS deployment target to 15.0 to match `StripeIdentity` 26.5.0
 - Raised the example app iOS deployment target to 15.1
 - Updated the example app to React Native 0.84.1
-- Updated compatibility with `stripe-react-native` [0.72.0](https://github.com/stripe/stripe-react-native/releases/tag/v0.72.0) if your app uses both SDKs
+- Updated compatibility with `stripe-react-native` [0.73.0](https://github.com/stripe/stripe-react-native/releases/tag/v0.73.0) if your app uses both SDKs
 - Refreshed root and example JS lockfiles to include newer transitive dependency versions
 
 # [v0.8.0](https://github.com/stripe/stripe-identity-react-native/releases/tag/v0.8.0) - 30 Apr 2026

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 # When StripeIdentityReactNative_kotlinVersion and StripeIdentityReactNative_stripeVersion is updated, also need to update StripeSdk_kotlinVersion and StripeSdk_stripeVersion in https://github.com/stripe/stripe-react-native/blob/master/android/gradle.properties
 StripeIdentityReactNative_kotlinVersion=2.2.21
-StripeIdentityReactNative_stripeVersion=23.13.1
+StripeIdentityReactNative_stripeVersion=23.14.0
 StripeIdentityReactNative_compileSdkVersion=36
 StripeIdentityReactNative_targetSdkVersion=36

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1854,17 +1854,17 @@ PODS:
     - React-utils (= 0.84.1)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.84.1)
-  - Stripe (26.4.1):
-    - StripeApplePay (= 26.4.1)
-    - StripeCore (= 26.4.1)
-    - StripeIssuing (= 26.4.1)
-    - StripePayments (= 26.4.1)
-    - StripePaymentsUI (= 26.4.1)
-    - StripeUICore (= 26.4.1)
+  - Stripe (26.5.0):
+    - StripeApplePay (= 26.5.0)
+    - StripeCore (= 26.5.0)
+    - StripeIssuing (= 26.5.0)
+    - StripePayments (= 26.5.0)
+    - StripePaymentsUI (= 26.5.0)
+    - StripeUICore (= 26.5.0)
   - stripe-identity-react-native (0.9.0):
     - React-Core
-    - StripeIdentity (= 26.4.1)
-  - stripe-react-native (0.72.0):
+    - StripeIdentity (= 26.5.0)
+  - stripe-react-native (0.73.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1885,10 +1885,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - stripe-react-native/Core (= 0.72.0)
-    - stripe-react-native/NewArch (= 0.72.0)
+    - stripe-react-native/Core (= 0.73.0)
+    - stripe-react-native/NewArch (= 0.73.0)
     - Yoga
-  - stripe-react-native/Core (0.72.0):
+  - stripe-react-native/Core (0.73.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1909,14 +1909,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (= 26.4.1)
-    - StripeApplePay (= 26.4.1)
-    - StripeFinancialConnections (= 26.4.1)
-    - StripePayments (= 26.4.1)
-    - StripePaymentSheet (= 26.4.1)
-    - StripePaymentsUI (= 26.4.1)
+    - Stripe (= 26.5.0)
+    - StripeApplePay (= 26.5.0)
+    - StripeFinancialConnections (= 26.5.0)
+    - StripePayments (= 26.5.0)
+    - StripePaymentSheet (= 26.5.0)
+    - StripePaymentsUI (= 26.5.0)
     - Yoga
-  - stripe-react-native/NewArch (0.72.0):
+  - stripe-react-native/NewArch (0.73.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1938,38 +1938,38 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (26.4.1):
-    - StripeCore (= 26.4.1)
-  - StripeCameraCore (26.4.1):
-    - StripeCore (= 26.4.1)
-  - StripeCore (26.4.1)
-  - StripeFinancialConnections (26.4.1):
-    - StripeCore (= 26.4.1)
-    - StripeUICore (= 26.4.1)
-  - StripeIdentity (26.4.1):
-    - StripeCameraCore (= 26.4.1)
-    - StripeCore (= 26.4.1)
-    - StripeUICore (= 26.4.1)
-  - StripeIssuing (26.4.1):
-    - StripeCore (= 26.4.1)
-    - StripePayments (= 26.4.1)
-    - StripePaymentsUI (= 26.4.1)
-  - StripePayments (26.4.1):
-    - StripeCore (= 26.4.1)
-    - StripePayments/Stripe3DS2 (= 26.4.1)
-  - StripePayments/Stripe3DS2 (26.4.1):
-    - StripeCore (= 26.4.1)
-  - StripePaymentSheet (26.4.1):
-    - StripeApplePay (= 26.4.1)
-    - StripeCore (= 26.4.1)
-    - StripePayments (= 26.4.1)
-    - StripePaymentsUI (= 26.4.1)
-  - StripePaymentsUI (26.4.1):
-    - StripeCore (= 26.4.1)
-    - StripePayments (= 26.4.1)
-    - StripeUICore (= 26.4.1)
-  - StripeUICore (26.4.1):
-    - StripeCore (= 26.4.1)
+  - StripeApplePay (26.5.0):
+    - StripeCore (= 26.5.0)
+  - StripeCameraCore (26.5.0):
+    - StripeCore (= 26.5.0)
+  - StripeCore (26.5.0)
+  - StripeFinancialConnections (26.5.0):
+    - StripeCore (= 26.5.0)
+    - StripeUICore (= 26.5.0)
+  - StripeIdentity (26.5.0):
+    - StripeCameraCore (= 26.5.0)
+    - StripeCore (= 26.5.0)
+    - StripeUICore (= 26.5.0)
+  - StripeIssuing (26.5.0):
+    - StripeCore (= 26.5.0)
+    - StripePayments (= 26.5.0)
+    - StripePaymentsUI (= 26.5.0)
+  - StripePayments (26.5.0):
+    - StripeCore (= 26.5.0)
+    - StripePayments/Stripe3DS2 (= 26.5.0)
+  - StripePayments/Stripe3DS2 (26.5.0):
+    - StripeCore (= 26.5.0)
+  - StripePaymentSheet (26.5.0):
+    - StripeApplePay (= 26.5.0)
+    - StripeCore (= 26.5.0)
+    - StripePayments (= 26.5.0)
+    - StripePaymentsUI (= 26.5.0)
+  - StripePaymentsUI (26.5.0):
+    - StripeCore (= 26.5.0)
+    - StripePayments (= 26.5.0)
+    - StripeUICore (= 26.5.0)
+  - StripeUICore (26.5.0):
+    - StripeCore (= 26.5.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2226,89 +2226,89 @@ SPEC CHECKSUMS:
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
   RCTSwiftUI: afc0a0a635860da1040a0b894bfd529da06d7810
-  RCTSwiftUIWrapper: 3197c020094f3b2151bb2d1223f7276787be8166
+  RCTSwiftUIWrapper: cbb32eb90f09bd42ea9ed1eecd51fef3294da673
   RCTTypeSafety: d13e192a37f151ce354641184bf4239844a3be17
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
-  React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
+  React-Core: bdaa87b276ca31877632a982ecf7c36f8c826414
   React-Core-prebuilt: 1e2520fb89757069223605d01c74d566d8f4e9bb
-  React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
-  React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
+  React-CoreModules: b24989f62d56390ae08ca4f65e6f38fe6802de42
+  React-cxxreact: 1a2dfcbc18a6b610664dba152adf327f063a0d12
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
-  React-defaultsnativemodule: bb85b1bdd9b4b82650cfa92998567fcfdb030145
-  React-domnativemodule: ffdba8ba4323387e821d8298be2013516036df87
-  React-Fabric: 8705ba7f14acf5b1df474d1af4b0191c69ac4690
-  React-FabricComponents: 5a1b5007fe8c5d5f043e45c335ebef2af0717fb2
-  React-FabricImage: e96eea6bb65b501cf5db3ce4ad057a97dea1dd69
-  React-featureflags: 410f6c383eb94019f63f105374d738169df291ae
-  React-featureflagsnativemodule: 5d6d7931ec5d4576639661c0f79169a0ae383023
-  React-graphics: b9b69adbe79d6944838aa304c849d78f977e9f21
-  React-hermes: 666c66bbc856b46dfa4b132f1c9efaa37ad419a1
-  React-idlecallbacksnativemodule: 785d307b9236ec9fb4ec0bcf99b34e8539d2d76e
-  React-ImageManager: daeef8b1c19803c71a9233f21f7f235cd3ec294e
-  React-intersectionobservernativemodule: c17189d2350205012682aefe566f7ebaa4f980e3
-  React-jserrorhandler: 431377b3d1783127bc394986fe8d932bcb8982fe
-  React-jsi: 33db13b95bb53827b03d9fb0f567d12b63dfc8ef
-  React-jsiexecutor: 49de4d48a7c4f283eaa865f7a4f3919f2c39be1c
-  React-jsinspector: 3ec7dd478806a0eb4ec6ab394e51a395e8f895ba
-  React-jsinspectorcdp: bcb79a666959b1a3e8aac3ff8209d05c719aaa2a
-  React-jsinspectornetwork: be3b81a6342b56c74dd0bdd58bf3f62f978c1472
-  React-jsinspectortracing: 293251deadf7c255da593bf1d9d337a645abdfdc
-  React-jsitooling: 6f729cdb85ff0c8294709ec1903e1f0c59662331
-  React-jsitracing: be95d903cc9440ab89a704c999dd7db6675dc47f
-  React-logger: b5521614afb8690420146dfc61a1447bb5d65419
-  React-Mapbuffer: f4ee8c62e0ef8359d139124f35a471518a172cd3
-  React-microtasksnativemodule: d1956f0eec54c619b63a379520fb4c618a55ccb9
-  react-native-safe-area-context: 3ee88d1c2899dd6e5e85a1a41920e0006d28ad35
-  React-NativeModulesApple: 5ba0903927f6b8d335a091700e9fda143980f819
-  React-networking: 3a4b7f9ed2b2d1c0441beacb79674323a24bcca6
+  React-defaultsnativemodule: 027cad46a2847719b5d3d20dd915463b06a5d4d1
+  React-domnativemodule: 5ddfc6b3b73b48a31dfa12f52d6b62527f6f260c
+  React-Fabric: 6ffcc768e2378e84ed428069c7e2d270ee78f2bf
+  React-FabricComponents: ee6614287222dd4f04fdb1263d1ae6eb7fe952c6
+  React-FabricImage: ab05740a08ad9e23e4e1701e9c354e9a9b048063
+  React-featureflags: a8b0c8d9a93b5903f7620408659de160d95e4efe
+  React-featureflagsnativemodule: 0f0fe1a044829f31d7565a4bdfded376fbcfdfc1
+  React-graphics: c497dd295c88729525a4752d524d2d783aa205d4
+  React-hermes: c2bde95033e6df1599b5c1b6d7e45736a8aa5cba
+  React-idlecallbacksnativemodule: 6ceacabe93be052bbe822fb018602f63a8e280e2
+  React-ImageManager: 820fe1d55add59ec053099a0c5abe830ecd6c699
+  React-intersectionobservernativemodule: f84958aaf662f95f837dc4d26cbb5e7dcc4b8f09
+  React-jserrorhandler: 390c6c46e2f639b5ba104385d7fba848396347e8
+  React-jsi: 382de7964299bbf878458006a14f52cb66a36cfc
+  React-jsiexecutor: b781400a9becfb24e36ac063dccb42a52dcb44ca
+  React-jsinspector: 0644f32cc9b09eae2bc845ceb58d03420ae70821
+  React-jsinspectorcdp: 96677569865afe25c737889e02d635db26131d9f
+  React-jsinspectornetwork: 28c7cac2e92b1739561dcffd07f5554e54050a85
+  React-jsinspectortracing: 58ee96f9580a143011f8b914ad6927b5116461a7
+  React-jsitooling: bc79639489d610c35731dd26e8e54c37e078996d
+  React-jsitracing: 1bb9fae4f2ccf891255a419cdfc13372d07ef4a5
+  React-logger: 517377b1d2ba7ac722d47fb2183b98de86632063
+  React-Mapbuffer: 45e088dfb58dc326ae20cca1814d3726553c4cad
+  React-microtasksnativemodule: ab9d1a05fe1f58ea44a97d307ef1b53463f45a3f
+  react-native-safe-area-context: 3e100877c7f7fdddb508b3900a3f1a14bde2cdbe
+  React-NativeModulesApple: b94faa2dce6d8c0a9d722ed7ee27b996d28b62d1
+  React-networking: e409d8fb062162da6293e98b77f8d80cf4430e07
   React-oscompat: ff26abf0ae3e3fdbe47b44224571e3fc7226a573
-  React-perflogger: a86b2146936f2ffa80188425c6e8892729e2ad01
-  React-performancecdpmetrics: 65b699c3e52c0a1d978d9cdf15e60c62e335b900
-  React-performancetimeline: b44f82caa563e46068d02d9cf5b0d2b84bdc7a6a
+  React-perflogger: 757c8c725cc20e94eba406885047f03cf83044fb
+  React-performancecdpmetrics: fec7e28b711c95ccb6fc7e3bb16572d88bcf27ae
+  React-performancetimeline: 4c6102f19df01db35c37a3e63a058cfbf1a056d9
   React-RCTActionSheet: fc1d5d419856868e7f8c13c14591ed63dadef43a
-  React-RCTAnimation: 2a1e7eeb55b71e8524db296fa31e46eeaa2d0da4
-  React-RCTAppDelegate: 317c1102a2d0bcc07567d8de58d9147102080b0e
-  React-RCTBlob: c82bbf96b2d1389550c05fb9739d4e85d471052e
-  React-RCTFabric: d82ad8120ba70fe63207e261b9e33d9b6077e2de
-  React-RCTFBReactNativeSpec: 4d33b5f3b339e9fa902168e8a1d62c458dda16e9
-  React-RCTImage: f959463e53ea731ab267e371eea1b92fccf27634
-  React-RCTLinking: 2a857113b8059ac4f0a8ae89f8aa312837b955d0
-  React-RCTNetwork: dc026bf25f6457249349be8cf8bd5fdf84cdfb14
-  React-RCTRuntime: b0630731fd864064066301e1e31406fea606d5f9
-  React-RCTSettings: e159e19475df2e92fd3b4ddcfe29f6cc12cf0ee4
-  React-RCTText: 7356cc84c2ed79635931891c176f72e0289dc75d
-  React-RCTVibration: 77621175b67b22e655ce4b29d1cda8498f2033e7
+  React-RCTAnimation: 1ce166ec15ab1f8eca8ebaae7f8f709d9be6958c
+  React-RCTAppDelegate: c752d93f597168a9a4d5678e9354bbb8d84df6d1
+  React-RCTBlob: 147d41ee9f80cf27fe9b2f7adc1d6d24f68ec3fc
+  React-RCTFabric: 712c4ad749a43712609011d178234c90a17cde12
+  React-RCTFBReactNativeSpec: 032ea8783dc27290ec6b9af9d8df5351847539a2
+  React-RCTImage: fd39f1c478f1e43357bc72c2dbdc2454aafe4035
+  React-RCTLinking: 02ca1c83536dab08130f5db4852f293c53885dd6
+  React-RCTNetwork: 85dc64c530e4b0be7436f9a15b03caba24e9a3a1
+  React-RCTRuntime: c75950caa80e6884cbf0417d8738992256890508
+  React-RCTSettings: df5da31865cc1bab7ef5314e65ca18f6b538d71d
+  React-RCTText: 41587e426883c9a83fd8eb0c57fe328aad4ed57a
+  React-RCTVibration: 8ca2f9839c53416dffb584adb94501431ba7f96e
   React-rendererconsistency: e91aba4bb482dac127ad955dba6333a8af629c5b
-  React-renderercss: 7cc41efaecf557d7b70edaa08fad5ace79f714f6
-  React-rendererdebug: 0f004cbed7b4c27327423be47209770830bf3c6d
-  React-RuntimeApple: 6f4ff8e2d8b05cb3ceabf57e494c04da8751f009
-  React-RuntimeCore: 25be9c7025eabb524cd00dbb6ce56d6b122e3d92
-  React-runtimeexecutor: 84d394b9f0a8fc7dab8a98bf88a43228bb04dac2
-  React-RuntimeHermes: 2bed5b2d2419945cc5c2f6d627a1b46ce3a0f66a
-  React-runtimescheduler: 23b092dbcd3088f9c947551c23366dd00254caf3
-  React-timing: 2ab9ccd4b41aa171090c16f664f6c5bfb2fd0ddc
-  React-utils: 8d888b379f0808bfabaea03d85f9e8dd9b8548da
-  React-webperformancenativemodule: c10016db7f1bb1153060d4aa9f7dbde2c88c845d
-  ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
-  ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
-  ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
+  React-renderercss: 1f15a79f3cc3c9416902b8f70266408116d93bd0
+  React-rendererdebug: 77dcf1490ee5c0ce141d2b1eaceed02aa0996826
+  React-RuntimeApple: 1074835708500a69770b713f718400137f30ce7a
+  React-RuntimeCore: 148db945742d7ce2985cc35b8ddc61edfdb46e6d
+  React-runtimeexecutor: 5742146dac0f8de9c21f5f703993df249c046d0d
+  React-RuntimeHermes: a5bb378bea92d526341a65afa945a38c9bc787b2
+  React-runtimescheduler: 91838dd32460920ed1b4da68590a2684b784aacc
+  React-timing: 9c0e2b1532317148fa0487bbc3833c1f348981a0
+  React-utils: 2f8dd43fed5c6d881ac5971666bbb34cc4a03fa1
+  React-webperformancenativemodule: afbee7a9fd0b5bf92f6765eb41767f865b293bcc
+  ReactAppDependencyProvider: 26bbf1e26768d08dd965a2b5e372e53f67b21fee
+  ReactCodegen: 4fa1b291ad275013e39212f2463c46480fb53afe
+  ReactCommon: 309419492d417c4cbb87af06f67735afa40ecb9d
   ReactNativeDependencies: dd348088487db963d16317be555a00af0d677c86
-  Stripe: 1d3402c1d9ac1a842e355784214abf1b6feb60e2
-  stripe-identity-react-native: 455684267ef79528f64d186dd901be31496af4a7
-  stripe-react-native: 3d67d733ddb6891ee1692531d4491df153c58ef4
-  StripeApplePay: 09150cd6fd99e8786cd03ddebc5417649163ea49
-  StripeCameraCore: d1a6eb6bc7c719c77e9a893950457c92b248900c
-  StripeCore: 838514a95b14b5b2afc1157c5af46cc0393e32a3
-  StripeFinancialConnections: b7594f4b2cfec59e3ba6150a0cdd338c7f260bdf
-  StripeIdentity: aefcf07d2dfbeccb304a14b4b396853e5139564f
-  StripeIssuing: b6b2549d65cb161113b40ac8422759fe3de98d19
-  StripePayments: 89720d0be84699e5beb684ac49bbf318ffb77ce4
-  StripePaymentSheet: 32cd0cbca9ea7dfa4d4ea9ba6c38729d147a26ac
-  StripePaymentsUI: e7075dc52ee0b5ee0b298cbf310de3e57f22d016
-  StripeUICore: 4d29f11936316fcced71f6fe2da0d6d1e6a46237
-  Yoga: c0b3f2c7e8d3e327e450223a2414ca3fa296b9a2
+  Stripe: 42c446f3f3ee60c2e96aa27491fd88cb849a3887
+  stripe-identity-react-native: d66f1dfd2cbc6ff9c576085ad29436ae3f965de6
+  stripe-react-native: 791148b68c49f9ea20fda2ecc40bf18f5a15b3fc
+  StripeApplePay: d6e62eb6150d7739e7a6aff99d3ed69905461fc4
+  StripeCameraCore: a404c9e95a0906668f62c40ce6ee15a890e6607f
+  StripeCore: ccde420bc8e878df43d356f8661702b921ace869
+  StripeFinancialConnections: fb8e12e36d2e5e79a1b5413c72900a9bf571fbe2
+  StripeIdentity: a773235907c17ae6c4a4b83492bdf365a89dc256
+  StripeIssuing: 104bad01e6a872713b81d44821eebc958a49d6cf
+  StripePayments: 43fb89181afd417966fa1e8bf7b8a0e5c85eb9ac
+  StripePaymentSheet: dbe9a57e2cef4d54630b56511f501d2c355e102d
+  StripePaymentsUI: 71c5666d50b62889d5f935f283ba6afb88135533
+  StripeUICore: aa5d5a1ff0e8a090078303915a5c14a0bce80a01
+  Yoga: 7c1c3b93e408ac46c7ed64b5641ca7161747378d
 
 PODFILE CHECKSUM: f7916aed2d2dafb4bdf17c8d0aa81a9d7f70a983
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@react-native/new-app-screen": "0.84.1",
     "@stripe/stripe-identity-react-native": "link:../",
-    "@stripe/stripe-react-native": "^0.72.0",
-    "react": "19.2.8",
+    "@stripe/stripe-react-native": "^0.73.0",
+    "react": "19.2.3",
     "react-native": "0.84.1",
     "react-native-dropdown-select-list": "^2.0.4",
     "react-native-radio-buttons-group": "^3.0.2",
@@ -36,7 +36,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.2.8",
+    "react-test-renderer": "19.2.3",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2088,10 +2088,10 @@
   version "0.0.0"
   uid ""
 
-"@stripe/stripe-react-native@^0.72.0":
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-react-native/-/stripe-react-native-0.72.0.tgz#a7958c1aaaf56b30423e684136ca844b5598c209"
-  integrity sha512-lgih4vvePfKmbMq2G/mFyrcPFWFeXEpPMmpYxS8cLF2cSTQ/tyulc1gM6dYw59k2SO8Qrkp0xzZUjX5TeX5Jag==
+"@stripe/stripe-react-native@^0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-react-native/-/stripe-react-native-0.73.0.tgz#3b242dbbb00a1b57375856be2dc6d5430eac7284"
+  integrity sha512-MfmuJCLK4O4Q5x3ssixHJB6oYSBhS6+3u+b+620OyPW4GqMD7X0b2nNvydwA3mTyA1QpGUV8vo/rkC0QYXYXog==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -5720,7 +5720,7 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-is@^19.2.8:
+react-is@^19.2.3:
   version "19.2.8"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.8.tgz#09826f9fbc187bc668e3e5c62edc001f804d5018"
   integrity sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==
@@ -5786,18 +5786,18 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
-react-test-renderer@19.2.8:
-  version "19.2.8"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.8.tgz#f4fb8c2a97c864ba708aec61d782a9bb725b672b"
-  integrity sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==
+react-test-renderer@19.2.3:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.3.tgz#d20f5193867c98b2df9e13b4e72bb83f311f6a43"
+  integrity sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==
   dependencies:
-    react-is "^19.2.8"
+    react-is "^19.2.3"
     scheduler "^0.27.0"
 
-react@19.2.8:
-  version "19.2.8"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
-  integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
+react@19.2.3:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.3.tgz#d83e5e8e7a258cf6b4fe28640515f99b87cd19b8"
+  integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
 
 readable-stream@^3.4.0:
   version "3.6.2"

--- a/stripe-identity-react-native.podspec
+++ b/stripe-identity-react-native.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 # When stripe_version is updated, also need to update stripe_version in https://github.com/stripe/stripe-react-native/blob/master/stripe-react-native.podspec
-stripe_version = '26.4.1'
+stripe_version = '26.5.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-identity-react-native'


### PR DESCRIPTION
## what changed

Updates the example app to `@stripe/stripe-react-native` 0.73.0 and keeps our native Stripe SDK versions in sync:

- stripe-react-native: 0.73.0
- stripe-android: 23.14.0
- stripe-ios: 26.5.0

This also aligns React and React Test Renderer with the `19.2.3` renderer used by React Native 0.84.1. that fixes the React version mismatch we hit while running the example on Android.

The JS and CocoaPods lockfiles were refreshed as part of the update.

## Testing

- Built and launched the example on a Pixel 7a running Android 16
- `yarn test --runInBand`
- `yarn typescript`
- `yarn --cwd example tsc --noEmit`
- `yarn lint`