### PR TITLE
Add test mode to the example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased]
 
+### Added
+
+- Added a test mode toggle to the example app for creating test Verification Sessions with sample document and selfie images
+
 ### Fixed
 
 - Aligned the example app's React and React Test Renderer versions with React Native 0.84.1

--- a/example/src/components/Options.tsx
+++ b/example/src/components/Options.tsx
@@ -150,6 +150,11 @@ export function Options({ options, setOptions }: OptionsProps) {
   if (options.verificationType === VerificationType.DOCUMENT) {
     return (
       <View style={styles.container}>
+        <Option
+          title="Use Test Mode"
+          value={options.useTestMode}
+          onChange={(value) => setOptions({ ...options, useTestMode: value })}
+        />
         <Text style={[styles.label, { color: colors.text }]}>Verification Type:</Text>
         <SelectList
           setSelected={onSelectVerificationType}
@@ -171,6 +176,11 @@ export function Options({ options, setOptions }: OptionsProps) {
   } else if (options.verificationType === VerificationType.PHONE) {
     return (
       <View style={styles.container}>
+        <Option
+          title="Use Test Mode"
+          value={options.useTestMode}
+          onChange={(value) => setOptions({ ...options, useTestMode: value })}
+        />
         <Text style={[styles.label, { color: colors.text }]}>Verification Type:</Text>
         <SelectList
           setSelected={onSelectVerificationType}
@@ -215,6 +225,11 @@ export function Options({ options, setOptions }: OptionsProps) {
   } else {
     return (
       <View style={styles.container}>
+        <Option
+          title="Use Test Mode"
+          value={options.useTestMode}
+          onChange={(value) => setOptions({ ...options, useTestMode: value })}
+        />
         <Text style={[styles.label, { color: colors.text }]}>Verification Type:</Text>
         <SelectList
           setSelected={onSelectVerificationType}

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -22,6 +22,7 @@ export function HomeScreen() {
   const colors = useAppThemeColors();
 
   const [options, setOptions] = useState<VerificationSessionOptions>({
+    useTestMode: false,
     verificationType: VerificationType.DOCUMENT,
     requireMatchingSelfie: false,
     requireIdNumber: false,

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -18,6 +18,7 @@ export enum PhoneOtpCheckTypes {
 }
 
 export type VerificationSessionOptions = {
+  useTestMode: boolean;
   verificationType: VerificationType;
   requireMatchingSelfie: boolean;
   requireIdNumber: boolean;

--- a/example/src/utils/__tests__/api.test.ts
+++ b/example/src/utils/__tests__/api.test.ts
@@ -1,0 +1,64 @@
+import {
+  AllowedTypes,
+  PhoneOtpCheckTypes,
+  VerificationSessionOptions,
+  VerificationType,
+} from '../../types';
+import { getTestCredentials } from '../api';
+
+const baseOptions: VerificationSessionOptions = {
+  useTestMode: false,
+  verificationType: VerificationType.DOCUMENT,
+  requireMatchingSelfie: false,
+  requireIdNumber: false,
+  allowedTypes: {
+    [AllowedTypes.DRIVING_LICENSE]: true,
+    [AllowedTypes.ID_CARD]: true,
+    [AllowedTypes.PASSPORT]: true,
+  },
+  requireLiveCapture: false,
+  requireAddress: false,
+  phoneFallbackToDocument: false,
+  phoneOtpCheckType: PhoneOtpCheckTypes.ATTEMPT,
+};
+
+const fetchMock = jest.fn();
+const originalFetch = globalThis.fetch;
+
+describe('getTestCredentials', () => {
+  beforeAll(() => {
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({
+        id: 'vs_123',
+        ephemeral_key_secret: 'ek_123',
+      }),
+    });
+  });
+
+  it('creates a live-mode Verification Session by default', async () => {
+    await getTestCredentials(baseOptions);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://stripe-mobile-identity-verification-playground.stripedemos.com/verification-sessions',
+      expect.any(Object)
+    );
+  });
+
+  it('creates a test-mode Verification Session when enabled', async () => {
+    await getTestCredentials({ ...baseOptions, useTestMode: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://stripe-mobile-identity-verification-playground.stripedemos.com/test/verification-sessions',
+      expect.any(Object)
+    );
+  });
+});

--- a/example/src/utils/api.ts
+++ b/example/src/utils/api.ts
@@ -4,15 +4,19 @@ import {
   VerificationType,
 } from '../types';
 
-// View and fork the backend code here: https://codesandbox.io/p/devbox/dsx4vq
+// View and fork the backend code here: https://codesandbox.io/p/devbox/compassionate-violet-gshhgf
 const baseURL =
   'https://stripe-mobile-identity-verification-playground.stripedemos.com';
-const verifyEndpoint = '/verification-sessions';
+const liveModeVerifyEndpoint = '/verification-sessions';
+const testModeVerifyEndpoint = '/test/verification-sessions';
 
 export const getTestCredentials = async (
   options: VerificationSessionOptions
 ) => {
   try {
+    const verifyEndpoint = options.useTestMode
+      ? testModeVerifyEndpoint
+      : liveModeVerifyEndpoint;
     let data;
     if (options.verificationType === VerificationType.DOCUMENT) {
       data = await fetch(baseURL + verifyEndpoint, {

--- a/example/src/utils/api.ts
+++ b/example/src/utils/api.ts
@@ -4,7 +4,6 @@ import {
   VerificationType,
 } from '../types';
 
-// View and fork the backend code here: https://codesandbox.io/p/devbox/compassionate-violet-gshhgf
 const baseURL =
   'https://stripe-mobile-identity-verification-playground.stripedemos.com';
 const liveModeVerifyEndpoint = '/verification-sessions';


### PR DESCRIPTION
## what changed

Adds a **Use Test Mode** switch to the example app, similar to the flow in [stripe-android#13755](https://github.com/stripe/stripe-android/pull/13755).

When enabled, the example creates the Verification Session through `/test/verification-sessions`. Otherwise, it continues using the existing live endpoint.

The switch is off by default.

Also added a couple of tests to make sure we call the correct endpoint for each mode.

## Testing

- `yarn test --runInBand`
- `yarn typescript`
- `yarn --cwd example tsc --noEmit`
- `yarn lint`